### PR TITLE
Fix images not being updated: add termination grace period to api and bot deployments

### DIFF
--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         component: api
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
         - name: api
           image: ghcr.io/tashima42/awa-bot:main
+          imagePullPolicy: "Always"
           env:
             - name: TZ
               value: "GMT-3"

--- a/k8s/bot-deployment.yaml
+++ b/k8s/bot-deployment.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         component: bot
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
         - name: bot
           image: ghcr.io/tashima42/awa-bot:main
+          imagePullPolicy: "Always"
           env:
             - name: TZ
               value: "GMT-3"


### PR DESCRIPTION
This PR is trying to fix a issue where the docker images were not being pulled before trying a deployment.

* Add termination grace period to bot and api deployments
* Add image pull policy 'always' to bot and api deployments